### PR TITLE
Changes for CMOR using Python 3

### DIFF
--- a/cmor/conda_build_config.yaml
+++ b/cmor/conda_build_config.yaml
@@ -1,6 +1,8 @@
 python:
     - 2.7
+    - 3.6
+    - 3.7
 numpy:
-    - 1.14
-    - 1.13
-    - 1.12
+    - 1.16
+fortran_compiler_version:   # [osx]
+    - 4.8.5                 # [osx]

--- a/cmor/conda_build_config.yaml
+++ b/cmor/conda_build_config.yaml
@@ -2,7 +2,5 @@ python:
     - 2.7
     - 3.6
     - 3.7
-numpy:
-    - 1.16
 fortran_compiler_version:   # [osx]
     - 4.8.5                 # [osx]

--- a/cmor/meta.yaml.in
+++ b/cmor/meta.yaml.in
@@ -25,7 +25,7 @@ requirements:
     - udunits2
     - hdf5
     - libnetcdf
-    - numpy >1.11
+    - numpy
     - setuptools
     - cdms2
   run:

--- a/cmor/meta.yaml.in
+++ b/cmor/meta.yaml.in
@@ -1,6 +1,6 @@
 package:
     name: cmor
-    version: @VERSION@
+    version: @VERSION@.numpy
 
 source:
     git_rev: @UVCDAT_BRANCH@

--- a/cmor/meta.yaml.in
+++ b/cmor/meta.yaml.in
@@ -1,6 +1,6 @@
 package:
     name: cmor
-    version: @VERSION@.npy{{ numpy }}
+    version: @VERSION@
 
 source:
     git_rev: @UVCDAT_BRANCH@

--- a/cmor/meta.yaml.in
+++ b/cmor/meta.yaml.in
@@ -25,7 +25,7 @@ requirements:
     - udunits2
     - hdf5
     - libnetcdf
-    - numpy
+    - numpy >1.11
     - setuptools
     - cdms2
   run:


### PR DESCRIPTION
The MacOS build currently gets a version of the gfortran compiler that is incompatible with the libgfortran library used by hdf5 and numpy from conda-forge.  This recipe gets the compatible version for OSX.
Fixes https://github.com/PCMDI/cmor/issues/451

The Python 3.7 builds have been failing for Numpy 1.12 and 1.13 as they do not support Python 3.7.  This recipe replaces all the Numpy versions with 1.16.
Fixes https://github.com/PCMDI/cmor/issues/459