### PR TITLE
Feedstock recipe

### DIFF
--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -13,6 +13,7 @@ from Utils import run_cmd, run_cmds, run_cmd_capture_output
 from Utils import SUCCESS, FAILURE
 from release_tools import prep_conda_env, check_if_conda_forge_pkg, clone_feedstock
 from release_tools import clone_repo, prepare_recipe_in_local_feedstock_repo
+from release_tools import copy_conda_config_yaml
 from release_tools import prepare_recipe_in_local_repo, rerender, do_build
 from release_tools import rerender_in_local_feedstock, build_in_local_feedstock
 from release_tools import rerender_in_local_repo, build_in_local_repo, get_git_rev
@@ -129,6 +130,10 @@ if is_conda_forge_pkg:
             sys.exit(status)
 
         status = prepare_recipe_in_local_feedstock_repo(pkg_name, organization, repo_name, branch, version, build, repo_dir, workdir)
+        if status != SUCCESS:
+            sys.exit(status)
+
+        status = copy_conda_config_yaml(pkg_name, repo_dir, workdir)
         if status != SUCCESS:
             sys.exit(status)
 

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -13,7 +13,7 @@ from Utils import run_cmd, run_cmds, run_cmd_capture_output
 from Utils import SUCCESS, FAILURE
 from release_tools import prep_conda_env, check_if_conda_forge_pkg, clone_feedstock
 from release_tools import clone_repo, prepare_recipe_in_local_feedstock_repo
-from release_tools import copy_conda_config_yaml
+from release_tools import copy_file_from_repo_recipe
 from release_tools import prepare_recipe_in_local_repo, rerender, do_build
 from release_tools import rerender_in_local_feedstock, build_in_local_feedstock
 from release_tools import rerender_in_local_repo, build_in_local_repo, get_git_rev
@@ -133,7 +133,13 @@ if is_conda_forge_pkg:
         if status != SUCCESS:
             sys.exit(status)
 
-        status = copy_conda_config_yaml(pkg_name, repo_dir, workdir)
+        status = copy_file_from_repo_recipe(pkg_name, repo_dir, workdir,
+                                            "conda_build_config.yaml")
+        if status != SUCCESS:
+            sys.exit(status)
+
+        status = copy_file_from_repo_recipe(pkg_name, repo_dir, workdir,
+                                            "build.sh")
         if status != SUCCESS:
             sys.exit(status)
 

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -323,6 +323,9 @@ def rerender(dir):
     print("Doing...'conda smithy rerender'...under {d}".format(d=dir))
     cmd = "conda smithy rerender"
     ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, dir)
+
+    cmd = "ls -l {d}".format(d=os.path.join(dir, ".ci_support"))
+    run_cmd(cmd, join_stderr, shell_cmd, verbose, dir)
     return ret
 
 def do_build(dir, py_version):

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -288,9 +288,9 @@ def copy_conda_config_yaml(pkg_name, repo_dir, workdir):
     if os.path.isfile(config):
         print("{c} exists in repo".format(c=config))
         pkg_feedstock = "{p}-feedstock".format(p=pkg_name)
-        feedstock_dir = os.path.join(workdir, pkg_feedstock)
+        feedstock_recipe_dir = os.path.join(workdir, pkg_feedstock, "recipe")
         cmd = "cp {c} {d}".format(c=config,
-                                  d=feedstock_dir)
+                                  d=feedstock_recipe_dir)
         #print("CMD: {c}".format(c=cmd))
         #os.system(cmd)
         ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, workdir)

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -152,14 +152,6 @@ def prepare_recipe_in_local_feedstock_repo(pkg_name, organization, repo_name, br
     orig_fh = open(recipe_file_source, "r")
     output_fh = open(recipe_file, "w")
 
-    #output_fh.write("package:\n")
-    #output_fh.write("  name: {n}\n".format(n=pkg_name))
-    #output_fh.write("  version: {v}\n\n".format(v=pkg_version))
-
-    #output_fh.write("source:\n")
-    #output_fh.write("  git_rev: {b}\n".format(b=branch))
-    #output_fh.write("  git_url: {r}\n".format(r=repo_url))
-
     start_copy = True
     lines = orig_fh.readlines()
     for l in lines:

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -299,6 +299,23 @@ def copy_conda_config_yaml(pkg_name, repo_dir, workdir):
         print("No {c} in repo".format(c=config))
     return SUCCESS
 
+def copy_file_from_repo_recipe(pkg_name, repo_dir, workdir, filename):
+
+    ret = SUCCESS
+    the_file = os.path.join(repo_dir, "recipe", filename)
+    if os.path.isfile(the_file):
+        print("{f} exists in repo".format(f=the_file))
+        pkg_feedstock = "{p}-feedstock".format(p=pkg_name)
+        feedstock_recipe_dir = os.path.join(workdir, pkg_feedstock, "recipe")
+        cmd = "cp {f} {d}".format(f=the_file,
+                                  d=feedstock_recipe_dir)
+        #print("CMD: {c}".format(c=cmd))
+        #os.system(cmd)
+        ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, workdir)
+    else:
+        print("No {f} in repo".format(f=the_file))
+    return ret
+
 def rerender(dir):
     # pkg_feedstock = "{p}-feedstock".format(p=pkg_name)
     # repo_dir = "{w}/{p}".format(w=workdir, p=pkg_feedstock)
@@ -306,12 +323,6 @@ def rerender(dir):
     print("Doing...'conda smithy rerender'...under {d}".format(d=dir))
     cmd = "conda smithy rerender"
     ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, dir)
-    if ret != SUCCESS:
-        return ret
-
-    cmd = "ls -l {d}/.ci_support".format(d=dir)
-    ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, dir)
-
     return ret
 
 def do_build(dir, py_version):

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -303,9 +303,9 @@ def rerender(dir):
     # pkg_feedstock = "{p}-feedstock".format(p=pkg_name)
     # repo_dir = "{w}/{p}".format(w=workdir, p=pkg_feedstock)
 
+    print("Doing...'conda smithy rerender'...under {d}".format(d))
     cmd = "conda smithy rerender"
     ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, dir)
-
     if ret != SUCCESS:
         return ret
 

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -283,6 +283,22 @@ def prepare_recipe_in_local_repo(branch, build, version, repo_dir):
 
     return SUCCESS
 
+def copy_conda_config_yaml(pkg_name, repo_dir, workdir):
+    config = os.path.join(repo_dir, "recipe", "conda_build_config.yaml")
+    if os.path.isfile(config):
+        print("{c} exists in repo".format(c=config))
+        pkg_feedstock = "{p}-feedstock".format(p=pkg_name)
+        feedstock_dir = os.path.join(workdir, pkg_feedstock)
+        cmd = "cp {c} {d}".format(c=config,
+                                  d=feedstock_dir)
+        #print("CMD: {c}".format(c=cmd))
+        #os.system(cmd)
+        ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, workdir)
+
+    else:
+        print("No {c} in repo".format(c=config))
+    return SUCCESS
+
 def rerender(dir):
     # pkg_feedstock = "{p}-feedstock".format(p=pkg_name)
     # repo_dir = "{w}/{p}".format(w=workdir, p=pkg_feedstock)

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -290,6 +290,12 @@ def rerender(dir):
     cmd = "conda smithy rerender"
     ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, dir)
 
+    if ret != SUCCESS:
+        return ret
+
+    cmd = "ls -l {d}/.ci_support"
+    ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, dir)
+
     return ret
 
 def do_build(dir, py_version):

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -293,7 +293,7 @@ def rerender(dir):
     if ret != SUCCESS:
         return ret
 
-    cmd = "ls -l {d}/.ci_support"
+    cmd = "ls -l {d}/.ci_support".format(d=dir)
     ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, dir)
 
     return ret

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -303,7 +303,7 @@ def rerender(dir):
     # pkg_feedstock = "{p}-feedstock".format(p=pkg_name)
     # repo_dir = "{w}/{p}".format(w=workdir, p=pkg_feedstock)
 
-    print("Doing...'conda smithy rerender'...under {d}".format(d))
+    print("Doing...'conda smithy rerender'...under {d}".format(d=dir))
     cmd = "conda smithy rerender"
     ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, dir)
     if ret != SUCCESS:

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -152,6 +152,80 @@ def prepare_recipe_in_local_feedstock_repo(pkg_name, organization, repo_name, br
     orig_fh = open(recipe_file_source, "r")
     output_fh = open(recipe_file, "w")
 
+    #output_fh.write("package:\n")
+    #output_fh.write("  name: {n}\n".format(n=pkg_name))
+    #output_fh.write("  version: {v}\n\n".format(v=pkg_version))
+
+    #output_fh.write("source:\n")
+    #output_fh.write("  git_rev: {b}\n".format(b=branch))
+    #output_fh.write("  git_url: {r}\n".format(r=repo_url))
+
+    start_copy = True
+    lines = orig_fh.readlines()
+    for l in lines:
+        match_obj = re.match("package:", l)
+        if match_obj:
+            start_copy = False
+            output_fh.write("package:\n")
+            output_fh.write("  name: {n}\n".format(n=pkg_name))
+            output_fh.write("  version: {v}\n\n".format(v=pkg_version))
+
+            output_fh.write("source:\n")
+            output_fh.write("  git_rev: {b}\n".format(b=branch))
+            output_fh.write("  git_url: {r}\n".format(r=repo_url))
+            continue
+
+        match_obj = re.match("build:", l)
+        if match_obj:
+            start_copy = True
+        
+        match_build_number = re.match("\s+number:", l)
+        if match_build_number:
+            output_fh.write("  number: {b}\n".format(b=build))
+            continue
+        if start_copy:
+            output_fh.write(l)
+        else:
+            continue
+    output_fh.close()
+    orig_fh.close()
+
+    cmd = "cat {f}".format(f=recipe_file)
+    #ret = run_cmd(cmd, join_stderr, shell_cmd, verbose)
+    print("CMD: {c}".format(c=cmd))
+    os.system(cmd)
+
+    return SUCCESS
+
+def ORIG_prepare_recipe_in_local_feedstock_repo(pkg_name, organization, repo_name, branch, pkg_version, build, repo_dir, workdir):
+    repo_url = "https://github.com/{o}/{r}.git\n\n".format(o=organization,r=repo_name)
+
+    pkg_feedstock = "{p}-feedstock".format(p=pkg_name)
+    feedstock_dir = os.path.join(workdir, pkg_feedstock)
+    recipe_file = os.path.join(feedstock_dir, 'recipe', 'meta.yaml')
+
+    #
+    # if repo has a recipe/meta.yaml.in, this means the branch is updating
+    # the recipe, use this recipe to build.
+    # NOTE: when we build the package for conda-forge, we will need to
+    # merge this recipe to feedstock and delete the recipe from the repo.
+    #
+    repo_recipe = os.path.join(repo_dir, "recipe", "meta.yaml.in")
+    if os.path.isfile(repo_recipe):
+        print("\nNOTE: {r} exists, we will build using this recipe.\n".format(r=repo_recipe))
+        recipe_file_source = repo_recipe
+    else:
+        print("\nNOTE: building with feedstock recipe with modified package source\n")
+        recipe_file_source = os.path.join(feedstock_dir, 'recipe', 'meta.yaml.SRC')
+
+        cmd = "mv {src} {dest}".format(src=recipe_file, dest=recipe_file_source)
+        ret = run_cmd(cmd, join_stderr, shell_cmd, verbose)
+        if ret != SUCCESS:
+            return ret
+
+    orig_fh = open(recipe_file_source, "r")
+    output_fh = open(recipe_file, "w")
+
     output_fh.write("package:\n")
     output_fh.write("  name: {n}\n".format(n=pkg_name))
     output_fh.write("  version: {v}\n\n".format(v=pkg_version))


### PR DESCRIPTION
added copy_file_from_repo_recipe() which is called when building a project that has a corresponding feedstock repo (i.e. it is a conda-forge package).
This function is called from build_tools/conda_build.py to copy recipe/build.sh and recipe/conda_build_config.sh from repo to feedstock repo if they exist.
This is to accomodate cases where we are making changes to those files.
Once we do a release and these files are merged to the copy in feedstock, we should remove these 2 files from the project repo.