### PR TITLE
Build tool update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,70 @@
 # conda-recipes
 
-# Building metapackages
+This repository contains tools for:
+* CDAT developers to build their conda packages, create a test environment, and upload the built package to conda channel. The tools are under *build_tools*, the main script is *build_tools/conda_build.py*. *conda_build.py* can be called from project's *Makefile* which can then be called from project's *.circleci/config.yml*.
 
-Make sure you have a version of `conda-build` that is at least `3.0.28`. Please run `conda update conda-build` before.
+# Notes for cdat developers
+
+In order to use *build_tools/conda_build.py*, create a conda environment, and activate the *base* environment. 
+
+## Clone conda-recipes repository.
+
+First clone conda-recipes repository to a work directory (referred as $WORKDIR in this documentation).
+
+```
+export WORKDIR=<some_work_directory>
+git clone https://github.com/CDAT/conda-recipes $WORKDIR/conda-recipes
+export BUILD_SCRIPT=$WORKDIR/conda-recipes/build_tools/conda_build.py
+```
+Run *build_tools/conda_build.py --help* to get information about this script.
+
+Clone the CDAT project you want to build. For example, to clone *cdms* project:
+
+```
+git clone https://github.com/CDAT/cdms
+```
+
+Set the following environment variables.
+  
+  export **PKG_NAME**=<package_name>
+  export **REPO_NAME**=<repo_name>
+  export **LAST_STABLE**=<last_stable_version>
+  export **BRANCH**=<project_branch>
+  export **CONDA_ACTIVATE**=<conda_path>/bin/activate
+
+For example:
+```
+export PKG_NAME=cdms2
+export REPO_NAME=cdms
+export LAST_STABLE=3.1.4
+export BRANCH=fix_flake8
+export CONDA_ACTIVATE=/home/username/miniconda3/bin/activate
+export PYTHON_VERSION=3.7
+```
+
+## Rerender
+
+
+First step in building a conda package is to do a rerendering which will pick up latest conda-forge update so that we get latest pinned dependencies.
+
+- Have *recipe/meta.yaml.in* in the project repo
+- 
+
+```bash
+$ python $BUILD_SCRIPT --workdir $WORKDIR --last_stable $LAST_STABLE \
+		       --build 0 --package_name $PKG_NAME --repo_name $REPO_NAME \
+		       --branch $BRANCH --do_rerender 
+```
+
+## Build
+
+```bash
+$ python $BUILD_SCRIPT --workdir $WORKDIR --package_name $PKG_NAME \
+  	 --repo_name $REPO_NAME --build_version $PYTHON_VERSION \
+	 --extra_channels "cdat/label/nightly conda-forge" \
+	 --conda_activate $CONDA_ACTIVATE --do_build
+```
+
+
+
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # conda-recipes
 
 This repository contains tools for:
-* CDAT developers to build their conda packages, create a test environment, and upload the built package to conda channel. The tools are under *build_tools*, the main script is *build_tools/conda_build.py*. *conda_build.py* can be called from project's *Makefile* which can then be called from project's *.circleci/config.yml*.
+- CDAT developers to build their conda packages, create a test environment, and upload the built package to conda channel. The tools are under *build_tools*, the main script is *build_tools/conda_build.py*. *conda_build.py* can be called from project's *Makefile* which can then be called from project's *.circleci/config.yml*.
 
-# Notes for cdat developers
+# Notes for CDAT developers
 
-In order to use *build_tools/conda_build.py*, create a conda environment, and activate the *base* environment. 
+In order to use *build_tools/conda_build.py*, create a conda environment and activate the *base* environment. 
 
 ## Clone conda-recipes repository.
 
-First clone conda-recipes repository to a work directory (referred as $WORKDIR in this documentation).
+Clone conda-recipes repository to a work directory (referred as $WORKDIR in this documentation).
 
 ```
 export WORKDIR=<some_work_directory>
@@ -22,16 +22,19 @@ Clone the CDAT project you want to build. For example, to clone *cdms* project:
 
 ```
 git clone https://github.com/CDAT/cdms
+cd cdms
 ```
 
 Set the following environment variables.
-  
+```bash  
   export **PKG_NAME**=<package_name>
   export **REPO_NAME**=<repo_name>
   export **LAST_STABLE**=<last_stable_version>
   export **BRANCH**=<project_branch>
   export **CONDA_ACTIVATE**=<conda_path>/bin/activate
   export **CONDA_ENV**=<test_environment_name>
+```
+
 For example:
 ```
 export PKG_NAME=cdms2
@@ -46,10 +49,7 @@ export CONDA_ENV=test_cdms
 ## Rerender
 
 
-First step in building a conda package is to do a rerendering which will pick up latest conda-forge update so that we get latest pinned dependencies.
-
-- Have *recipe/meta.yaml.in* in the project repo
-- 
+First step in building a conda package is to do a rerendering which will pick up latest conda-forge update so that we get latest pinned dependencies. You will need *recipe/meta.yaml.in* in the project repo
 
 ```bash
 $ python $BUILD_SCRIPT --workdir $WORKDIR --last_stable $LAST_STABLE \

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ cd cdms
 
 Set the following environment variables.
 ```bash  
-  export **PKG_NAME**=<package_name>
-  export **REPO_NAME**=<repo_name>
-  export **LAST_STABLE**=<last_stable_version>
-  export **BRANCH**=<project_branch>
-  export **CONDA_ACTIVATE**=<conda_path>/bin/activate
-  export **CONDA_ENV**=<test_environment_name>
+  export PKG_NAME=<package_name>
+  export REPO_NAME=<repo_name>
+  export LAST_STABLE=<last_stable_version>
+  export BRANCH=<project_branch>
+  export CONDA_ACTIVATE=<conda_path>/bin/activate
+  export CONDA_ENV=<test_environment_name>
 ```
 
 For example:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Set the following environment variables.
   export **LAST_STABLE**=<last_stable_version>
   export **BRANCH**=<project_branch>
   export **CONDA_ACTIVATE**=<conda_path>/bin/activate
-
+  export **CONDA_ENV**=<test_environment_name>
 For example:
 ```
 export PKG_NAME=cdms2
@@ -40,6 +40,7 @@ export LAST_STABLE=3.1.4
 export BRANCH=fix_flake8
 export CONDA_ACTIVATE=/home/username/miniconda3/bin/activate
 export PYTHON_VERSION=3.7
+export CONDA_ENV=test_cdms
 ```
 
 ## Rerender
@@ -59,10 +60,21 @@ $ python $BUILD_SCRIPT --workdir $WORKDIR --last_stable $LAST_STABLE \
 ## Build
 
 ```bash
+$ export EXTRA_CHANNELS=cdat/label/nightly
 $ python $BUILD_SCRIPT --workdir $WORKDIR --package_name $PKG_NAME \
   	 --repo_name $REPO_NAME --build_version $PYTHON_VERSION \
-	 --extra_channels "cdat/label/nightly conda-forge" \
+	 --extra_channels $EXTRA_CHANNELS \
 	 --conda_activate $CONDA_ACTIVATE --do_build
+```
+
+## Setup an environment with the built package
+```bash
+conda create -y -n $CONDA_ENV --use-local -c $EXTRA_CHANNEL $PKG_NAME 
+```
+
+For example, to create a test environment for running cdms test cases:
+```bash
+conda create -y -n $CONDA_ENV --use-local -c $EXTRA_CHANNELS $PKG_NAME testsrunner pytest
 ```
 
 

--- a/build_tools/Utils.py
+++ b/build_tools/Utils.py
@@ -7,7 +7,7 @@ import time
 SUCCESS = 0
 FAILURE = 1
 
-def run_command(cmd, join_stderr=True, shell_cmd=False, verbose=True, cwd=None):
+def run_command(cmd, join_stderr=True, shell_cmd=False, verbose=True, cwd=None, env=None):
     print("CMD: {c}".format(c=cmd))
     if isinstance(cmd, str):
         cmd = shlex.split(cmd)
@@ -22,8 +22,14 @@ def run_command(cmd, join_stderr=True, shell_cmd=False, verbose=True, cwd=None):
     else:
         current_wd = cwd
 
+    new_env = os.environ.copy()
+
+    if env is not None:
+        new_env.update(env)
+
     P = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=stderr_setting,
-        bufsize=0, cwd=current_wd, shell=shell_cmd)
+        bufsize=0, cwd=current_wd, shell=shell_cmd, env=new_env)
+
     out = []
     while P.poll() is None:
         read = P.stdout.readline().rstrip()
@@ -34,21 +40,21 @@ def run_command(cmd, join_stderr=True, shell_cmd=False, verbose=True, cwd=None):
 
     ret_code = P.returncode
     return(ret_code, out)
-                                                                                              
-def run_cmd(cmd, join_stderr=True, shell_cmd=False, verbose=True, cwd=None):
 
-    ret_code, output = run_command(cmd, join_stderr, shell_cmd, verbose, cwd)
+def run_cmd(cmd, join_stderr=True, shell_cmd=False, verbose=True, cwd=None, env=None):
+
+    ret_code, output = run_command(cmd, join_stderr, shell_cmd, verbose, cwd, env)
     return(ret_code)
 
-def run_cmds(cmds, join_stderr=True, shell_cmd=False, verbose=True, cwd=None):
+def run_cmds(cmds, join_stderr=True, shell_cmd=False, verbose=True, cwd=None, env=None):
     for cmd in cmds:
-        ret_code, output = run_command(cmd, join_stderr, shell_cmd, verbose, cwd)
+        ret_code, output = run_command(cmd, join_stderr, shell_cmd, verbose, cwd, env)
         if ret_code != SUCCESS:
             return ret_code
     return ret_code
 
-def run_cmd_capture_output(cmd, join_stderr=True, shell_cmd=False, verbose=True, cwd=None):
+def run_cmd_capture_output(cmd, join_stderr=True, shell_cmd=False, verbose=True, cwd=None, env=None):
 
-    ret_code, output = run_command(cmd, join_stderr, shell_cmd, verbose, cwd)
+    ret_code, output = run_command(cmd, join_stderr, shell_cmd, verbose, cwd, env)
     return(ret_code, output)
 

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -166,6 +166,7 @@ if is_conda_forge_pkg:
         status = rerender_in_local_feedstock(**kwargs)
 
     if args.do_build:
+        print("DEBUG DEBUG...copy_conda_package: {c}".format(c=kwargs["copy_conda_package"]))
         status = build_in_local_feedstock(**kwargs)
 
 else:

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -166,7 +166,6 @@ if is_conda_forge_pkg:
         status = rerender_in_local_feedstock(**kwargs)
 
     if args.do_build:
-        print("DEBUG DEBUG...copy_conda_package: {c}".format(c=kwargs["copy_conda_package"]))
         status = build_in_local_feedstock(**kwargs)
 
 else:

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -197,7 +197,7 @@ else:
 
         status = rerender_in_local_repo(repo_dir=feedstock_dir, **kwargs)
     else:
-        feedstock_dir = os.path.join(workdir, "{}-feedstock", pkg_name)
+        feedstock_dir = os.path.join(workdir, "{}-feedstock".format(pkg_name))
 
     if args.do_build:
         status = build_in_local_repo(repo_dir=feedstock_dir, py_version=args.build_version, **kwargs)

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -73,7 +73,7 @@ parser.add_argument("--do_rerender", action='store_true', help="do 'conda smithy
 parser.add_argument("--do_build", action='store_true', help="do 'conda build -m <variant file> ...'")
 parser.add_argument("--build_version", default="3.7", help="specify python version to build 2.7, 3.7, 3.8")
 parser.add_argument("--conda_env", default="base", help="Conda environment to use, will be created if it doesn't exist")
-parser.add_argument("--extra_channels", nargs="+", type=str)
+parser.add_argument("--extra_channels", nargs="+", type=str, default=[])
 parser.add_argument("--ignore_conda_missmatch", action="store_true", help="Will skip checking if packages are uptodate when rerendering recipe.")
 parser.add_argument("--conda_rc", default=conda_rc, help="File to use for condarc")
 

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -86,6 +86,8 @@ else:
 # github organization of projects
 organization = args.github_organization_name
 
+status = FAILURE
+
 # for calling run_cmds
 join_stderr = True
 shell_cmd = False

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -77,6 +77,7 @@ parser.add_argument("--extra_channels", nargs="+", type=str, default=[])
 parser.add_argument("--ignore_conda_missmatch", action="store_true", help="Will skip checking if packages are uptodate when rerendering recipe.")
 parser.add_argument("--conda_rc", default=conda_rc, help="File to use for condarc")
 parser.add_argument("--conda_activate", help="Path to conda activate script.")
+parser.add_argument("--copy_conda_package", help="Copies output conda package to directory")
 
 args = parser.parse_args(sys.argv[1:])
 

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -76,6 +76,7 @@ parser.add_argument("--conda_env", default="base", help="Conda environment to us
 parser.add_argument("--extra_channels", nargs="+", type=str, default=[])
 parser.add_argument("--ignore_conda_missmatch", action="store_true", help="Will skip checking if packages are uptodate when rerendering recipe.")
 parser.add_argument("--conda_rc", default=conda_rc, help="File to use for condarc")
+parser.add_argument("--conda_activate", help="Path to conda activate script.")
 
 args = parser.parse_args(sys.argv[1:])
 
@@ -120,7 +121,11 @@ def construct_pkg_ver(repo_dir, arg_version, arg_last_stable):
 #
 
 kwargs = vars(args)
-kwargs["conda_activate"] = find_conda_activate()
+kwargs["conda_activate"] = args.conda_activate or find_conda_activate()
+
+if kwargs["conda_activate"] is None:
+    print("Could not find conda activate script, try passing with --conda_activate argument")
+    sys.exit(FAILURE)
 
 is_conda_forge_pkg = check_if_conda_forge_pkg(pkg_name)
 

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -78,7 +78,7 @@ parser.add_argument("--ignore_conda_missmatch", action="store_true", help="Will 
 parser.add_argument("--conda_rc", default=conda_rc, help="File to use for condarc")
 parser.add_argument("--conda_activate", help="Path to conda activate script.")
 parser.add_argument("--copy_conda_package", help="Copies output conda package to directory")
-parser.add_argument("--local_repo", help="Path to local project repository, must contain recipe/ directory")
+parser.add_argument("--local_repo", help="Path to local project repository")
 
 args = parser.parse_args(sys.argv[1:])
 
@@ -94,10 +94,6 @@ local_repo = args.local_repo
 if local_repo is not None and not os.path.exists(local_repo):
     print("Local repository {} does not exist".format(local_repo))
     sys.exit(FAILURE)
-
-    if not os.path.exists(os.path.join(local_repo, "recipe")):
-        print("Did not find recipe directory in local repository {}".format(local_repo))
-        sys.exit(FAILURE)
 
 if args.repo_name:
     repo_name = args.repo_name

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -8,7 +8,7 @@ from Utils import SUCCESS, FAILURE
 from release_tools import find_conda_activate, create_fake_feedstock
 from release_tools import prep_conda_env, check_if_conda_forge_pkg, clone_feedstock
 from release_tools import clone_repo, prepare_recipe_in_local_feedstock_repo
-from release_tools import copy_file_from_repo_recipe
+from release_tools import copy_files_from_repo
 from release_tools import prepare_recipe_in_local_repo, rerender, do_build
 from release_tools import rerender_in_local_feedstock, build_in_local_feedstock
 from release_tools import rerender_in_local_repo, build_in_local_repo, get_git_rev
@@ -145,6 +145,11 @@ else:
     else:
         repo_dir = local_repo
 
+print("repo_dir: {d}".format(d=repo_dir))
+files = ["recipe/conda_build_config.yaml",
+         "recipe/build.sh",
+         ".ci_support/migrations/python38.yaml"]
+
 if is_conda_forge_pkg:
     if args.do_rerender:
         status = clone_feedstock(**kwargs)
@@ -155,11 +160,7 @@ if is_conda_forge_pkg:
         if status != SUCCESS:
             sys.exit(status)
 
-        status = copy_file_from_repo_recipe(repo_dir=repo_dir, filename="conda_build_config.yaml", **kwargs)
-        if status != SUCCESS:
-            sys.exit(status)
-
-        status = copy_file_from_repo_recipe(repo_dir=repo_dir, filename="build.sh", **kwargs)
+        status = copy_files_from_repo(repo_dir=repo_dir, filenames=files, **kwargs)
         if status != SUCCESS:
             sys.exit(status)
 
@@ -176,12 +177,15 @@ else:
 
     if args.do_rerender:
         status = prepare_recipe_in_local_repo(repo_dir=repo_dir, **kwargs)
-
         if status != SUCCESS:
             sys.exit(status)
 
         # Create a fake feedstock in the workdir to run conda smithy in
         feedstock_dir = create_fake_feedstock(repo_dir=repo_dir, **kwargs)
+
+        status = copy_files_from_repo(repo_dir=repo_dir, filenames=files, **kwargs)
+        if status != SUCCESS:
+            sys.exit(status)
 
         status = rerender_in_local_repo(repo_dir=feedstock_dir, **kwargs)
     else:

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -197,7 +197,7 @@ else:
 
         status = rerender_in_local_repo(repo_dir=feedstock_dir, **kwargs)
     else:
-        feedstock_dir = os.path.join(workdir, "feedstock")
+        feedstock_dir = os.path.join(workdir, "{}-feedstock", pkg_name)
 
     if args.do_build:
         status = build_in_local_repo(repo_dir=feedstock_dir, py_version=args.build_version, **kwargs)

--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -124,8 +124,8 @@ def construct_pkg_ver(repo_dir, arg_version, arg_last_stable):
 kwargs = vars(args)
 kwargs["conda_activate"] = args.conda_activate or find_conda_activate()
 
-if kwargs["conda_activate"] is None:
-    print("Could not find conda activate script, try passing with --conda_activate argument")
+if kwargs["conda_activate"] is None or not os.path.exists(kwargs["conda_activate"]):
+    print("Could not find conda activate script, try passing with --conda_activate argument and check file exists")
     sys.exit(FAILURE)
 
 is_conda_forge_pkg = check_if_conda_forge_pkg(pkg_name)

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -288,7 +288,7 @@ def rerender(conda_activate, conda_env, conda_rc, dir, **kwargs):
     run_cmd(cmd, join_stderr, shell_cmd, verbose, dir)
     return ret
 
-def do_build(conda_activate, conda_env, conda_rc, dir, py_version, **kwargs):
+def do_build(conda_activate, conda_env, conda_rc, dir, py_version, copy_conda_package, **kwargs):
     print("...do_build..., py_version: {v}".format(v=py_version))
     ret = SUCCESS
     env = {"CONDARC": conda_rc}
@@ -297,6 +297,11 @@ def do_build(conda_activate, conda_env, conda_rc, dir, py_version, **kwargs):
         variant_file = os.path.join(variant_files_dir, "linux_.yaml")
         cmd = "source {} {}; conda build -m {} recipe/".format(conda_activate, conda_env, variant_file)
         ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, dir, env=env)
+
+        if copy_conda_package is not None:
+            cmd = "source {} {}; output=$(conda build --output -m {} recipe/); cp $output {}".format(
+                    conda_activate, conda_env, variant_file, copy_conda_package)
+            ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, dir, env=env)
     else:
         if sys.platform == 'darwin':
             variant_files = glob.glob("{d}/.ci_support/osx*{v}*.yaml".format(d=dir, v=py_version))
@@ -309,6 +314,11 @@ def do_build(conda_activate, conda_env, conda_rc, dir, py_version, **kwargs):
             if ret != SUCCESS:
                 print("FAIL: {c}".format(c=cmd))
                 break
+
+            if copy_conda_package is not None:
+                cmd = "source {} {}; output=$(conda build --output -m {} recipe/); cp $output {}".format(
+                        conda_activate, conda_env, variant_file, copy_conda_package)
+                ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, dir, env=env)
 
     return ret
 

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -328,6 +328,7 @@ def rerender_in_local_feedstock(package_name, workdir, **kwargs):
     return ret
 
 def build_in_local_feedstock(package_name, workdir, build_version, **kwargs):
+    print("DEBUG DEBUG...build_in_local_feedstock(), copy_conda_package: {d}".format(d=kwargs[copy_conda_package]))
     pkg_feedstock = "{p}-feedstock".format(p=package_name)
     repo_dir = os.path.join(workdir, pkg_feedstock)
 

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -214,7 +214,7 @@ def prepare_recipe_in_local_feedstock_repo(pkg_name, organization, repo_name, br
 
     return SUCCESS
 
-def prepare_recipe_in_local_repo(branch, build, version, repo_dir):
+def prepare_recipe_in_local_repo(branch, build, version, repo_dir, **kwargs):
     recipe_in_file = os.path.join(repo_dir, "recipe", "meta.yaml.in")
     recipe_file = os.path.join(repo_dir, "recipe", "meta.yaml")
     if not os.path.isfile(recipe_in_file):
@@ -377,6 +377,20 @@ def find_conda_activate():
                 break
 
     return activate
+
+def create_fake_feedstock(conda_activate, conda_env, workdir, repo_dir, **kwargs):
+    feedstock_dir = os.path.join(workdir, "feedstock")
+
+    if not os.path.exists(feedstock_dir):
+        os.makedirs(feedstock_dir)
+
+    cmd = "source {} {}; conda smithy ci-skeleton {}".format(conda_activate, conda_env, feedstock_dir)
+    ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, feedstock_dir)
+
+    cmd = "cp {}/recipe/* {}/recipe".format(repo_dir, feedstock_dir)
+    ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, repo_dir)
+
+    return feedstock_dir
 
 #latest_tag = get_latest_tag("/Users/muryanto1/work/release/cdms")
 #print("xxx latest_tag: {t}".format(t=latest_tag))

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -309,10 +309,11 @@ def do_build(conda_activate, conda_env, conda_rc, dir, py_version, copy_conda_pa
             if ret != SUCCESS:
                 print("FAIL: {c}".format(c=cmd))
                 break
-
+            print("DEBUG DEBUG...here in do_build()...")
             if copy_conda_package is not None:
                 cmd = "source {} {}; output=$(conda build --output -m {} recipe/); cp $output {}".format(
                         conda_activate, conda_env, variant_file, copy_conda_package)
+                print("DEBUG DEBUG...cmd: {c}".format(c=cmd))
                 ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, dir, env=env)
 
     return ret

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -77,7 +77,7 @@ def prep_conda_env(conda_activate, conda_rc, conda_env, extra_channels, to_do_co
         "{} --add channels conda-forge --force".format(base_config_cmd),
     ]
 
-    channels = ["{} --add channels {} --force".format(base_config_cmd, x) for x in extra_channels]
+    channels = ["{} --add channels {} --force".format(base_config_cmd, x) for x in reversed(extra_channels)]
 
     ret = run_cmds(cmds+channels)
 

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -295,8 +295,8 @@ def do_build(conda_activate, conda_env, conda_rc, dir, py_version, **kwargs):
     variant_files_dir = os.path.join(dir, ".ci_support")
     if py_version == "noarch":
         variant_file = os.path.join(variant_files_dir, "linux_.yaml")
-        cmd = "source {} {}; conda build -m {} recipe/".format(conda_activate, conda_env, variant_file, env=env)
-        ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, dir)
+        cmd = "source {} {}; conda build -m {} recipe/".format(conda_activate, conda_env, variant_file)
+        ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, dir, env=env)
     else:
         if sys.platform == 'darwin':
             variant_files = glob.glob("{d}/.ci_support/osx*{v}*.yaml".format(d=dir, v=py_version))
@@ -304,8 +304,8 @@ def do_build(conda_activate, conda_env, conda_rc, dir, py_version, **kwargs):
             variant_files = glob.glob("{d}/.ci_support/linux*{v}*.yaml".format(d=dir, v=py_version))
 
         for variant_file in variant_files:
-            cmd = "source {} {}; conda build -m {} recipe/".format(conda_activate, conda_env, variant_file, env=env)
-            ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, dir)
+            cmd = "source {} {}; conda build -m {} recipe/".format(conda_activate, conda_env, variant_file)
+            ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, dir, env=env)
             if ret != SUCCESS:
                 print("FAIL: {c}".format(c=cmd))
                 break

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -81,7 +81,8 @@ def prep_conda_env(conda_activate, conda_rc, conda_env, extra_channels, to_do_co
 
     ret = run_cmds(cmds+channels)
 
-    ret = run_cmd("conda info", env=env)
+    cmd = "source {} {}; conda info".format(conda_activate, conda_env)
+    ret = run_cmd(["/bin/bash", "-c", cmd], env=env)
 
     if conda_env != "base":
         cmd = "source {} base; conda env remove -n {} -y".format(conda_activate, conda_env)

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -311,8 +311,8 @@ def do_build(conda_activate, conda_env, conda_rc, dir, py_version, copy_conda_pa
                 break
             print("DEBUG DEBUG...here in do_build()...")
             if copy_conda_package is not None:
-                cmd = "source {} {}; output=$(conda build --output -m {} recipe/); cp $output {}".format(
-                        conda_activate, conda_env, variant_file, copy_conda_package)
+                cmd = "source {} {}; output=$(conda build --output -m {} recipe/); mkdir -p {}; cp $output {}".format(
+                        conda_activate, conda_env, variant_file, copy_conda_package, copy_conda_package)
                 print("DEBUG DEBUG...cmd: {c}".format(c=cmd))
                 ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, dir, env=env)
 

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -246,22 +246,40 @@ def prepare_recipe_in_local_repo(branch, build, version, repo_dir, local_repo, *
 
     return SUCCESS
 
-def copy_file_from_repo_recipe(package_name, repo_dir, workdir, filename, **kwargs):
+def copy_file_from_repo(package_name, repo_dir, workdir, filename, **kwargs):
 
+    print("...copy_file_from_repo(), filename: {f}".format(f=filename))
     ret = SUCCESS
-    the_file = os.path.join(repo_dir, "recipe", filename)
+    the_file = os.path.join(repo_dir, filename)
+    print("...the_file: {f}".format(f=the_file))
     if os.path.isfile(the_file):
         print("{f} exists in repo".format(f=the_file))
         pkg_feedstock = "{p}-feedstock".format(p=package_name)
-        feedstock_recipe_dir = os.path.join(workdir, pkg_feedstock, "recipe")
+        feedstock_dest_dir = os.path.dirname(os.path.join(workdir, pkg_feedstock, filename))
+        if not os.path.exists(feedstock_dest_dir):
+            print("...making {d}".format(d=feedstock_dest_dir))
+            os.makedirs(feedstock_dest_dir)
+
         cmd = "cp {f} {d}".format(f=the_file,
-                                  d=feedstock_recipe_dir)
+                                  d=feedstock_dest_dir)
         #print("CMD: {c}".format(c=cmd))
         #os.system(cmd)
         ret = run_cmd(cmd, join_stderr, shell_cmd, verbose, workdir)
     else:
         print("No {f} in repo".format(f=the_file))
     return ret
+
+def copy_files_from_repo(package_name, repo_dir, workdir, filenames, **kwargs):
+
+    print("...copy_files_from_repo()...")
+    for f in filenames:
+        print("DEBUG...file: {f}".format(f=f))
+        ret = copy_file_from_repo(package_name, repo_dir, workdir, f, **kwargs)
+        if ret != SUCCESS:
+            print("FAIL in copying {f}".format(f=f))
+            return ret
+
+    return SUCCESS
 
 def rerender(conda_activate, conda_env, conda_rc, dir, **kwargs):
     # pkg_feedstock = "{p}-feedstock".format(p=pkg_name)

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -328,7 +328,7 @@ def rerender_in_local_feedstock(package_name, workdir, **kwargs):
     return ret
 
 def build_in_local_feedstock(package_name, workdir, build_version, **kwargs):
-    print("DEBUG DEBUG...build_in_local_feedstock(), copy_conda_package: {d}".format(d=kwargs[copy_conda_package]))
+    print("DEBUG DEBUG...build_in_local_feedstock(), copy_conda_package: {d}".format(d=kwargs["copy_conda_package"]))
     pkg_feedstock = "{p}-feedstock".format(p=package_name)
     repo_dir = os.path.join(workdir, pkg_feedstock)
 

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -90,7 +90,7 @@ def prep_conda_env(conda_activate, conda_rc, conda_env, extra_channels, to_do_co
     pkgs = "conda-build anaconda-client conda-smithy conda-verify conda-forge-pinning conda-forge-build-setup conda-forge-ci-setup"
 
     if conda_env == "base":
-        cmd = "source {} base; conda install -y {}".format(conda_activate, conda_env, pkgs)
+        cmd = "source {} base; conda install -y {}".format(conda_activate, pkgs)
         ret = run_cmd(["/bin/bash", "-c", cmd], env=env)
     else:
         cmd = "source {} base; conda create -n {} -y {}".format(conda_activate, conda_env, pkgs)

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -309,11 +309,9 @@ def do_build(conda_activate, conda_env, conda_rc, dir, py_version, copy_conda_pa
             if ret != SUCCESS:
                 print("FAIL: {c}".format(c=cmd))
                 break
-            print("DEBUG DEBUG...here in do_build()...")
             if copy_conda_package is not None:
                 cmd = "source {} {}; output=$(conda build --output -m {} recipe/); mkdir -p {}; cp $output {}".format(
                         conda_activate, conda_env, variant_file, copy_conda_package, copy_conda_package)
-                print("DEBUG DEBUG...cmd: {c}".format(c=cmd))
                 ret = run_cmd(["/bin/bash", "-c", cmd], join_stderr, shell_cmd, verbose, dir, env=env)
 
     return ret
@@ -328,7 +326,6 @@ def rerender_in_local_feedstock(package_name, workdir, **kwargs):
     return ret
 
 def build_in_local_feedstock(package_name, workdir, build_version, **kwargs):
-    print("DEBUG DEBUG...build_in_local_feedstock(), copy_conda_package: {d}".format(d=kwargs["copy_conda_package"]))
     pkg_feedstock = "{p}-feedstock".format(p=package_name)
     repo_dir = os.path.join(workdir, pkg_feedstock)
 

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -77,7 +77,7 @@ def prep_conda_env(conda_activate, conda_rc, conda_env, extra_channels, to_do_co
         "{} --add channels conda-forge --force".format(base_config_cmd),
     ]
 
-    channels = ["{} --add channels {} --force".format(base_config_cmd, x) for x in reversed(extra_channels)]
+    channels = ["{} --add channels {} --force".format(base_config_cmd, x) for x in extra_channels]
 
     ret = run_cmds(cmds+channels)
 

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -84,13 +84,17 @@ def prep_conda_env(conda_activate, conda_rc, conda_env, extra_channels, to_do_co
     ret = run_cmd("conda info", env=env)
 
     if conda_env != "base":
-        cmd = ["/bin/bash", "-c", "source {} base; conda env remove -n {} -y".format(conda_activate, conda_env)]
-        ret = run_cmd(cmd, env=env)
+        cmd = "source {} base; conda env remove -n {} -y".format(conda_activate, conda_env)
+        ret = run_cmd(["/bin/bash", "-c", cmd], env=env)
 
     pkgs = "conda-build anaconda-client conda-smithy conda-verify conda-forge-pinning conda-forge-build-setup conda-forge-ci-setup"
 
-    cmd = ["/bin/bash", "-c", "source {} base; conda create -n {} -y {}".format(conda_activate, conda_env, pkgs)]
-    ret = run_cmd(cmd, env=env)
+    if conda_env == "base":
+        cmd = "source {} base; conda install -y {}".format(conda_activate, conda_env, pkgs)
+        ret = run_cmd(["/bin/bash", "-c", cmd], env=env)
+    else:
+        cmd = "source {} base; conda create -n {} -y {}".format(conda_activate, conda_env, pkgs)
+        ret = run_cmd(["/bin/bash", "-c", cmd], env=env)
 
     if to_do_conda_clean:
         cmd = "source {} {}; conda clean --all".format(conda_activate, conda_env)


### PR DESCRIPTION
Adds some new cli arguments:
- **conda_env**: Specifies the conda environment to use.
- **extra_channels**: List of channels to set in the condarc.
- **ignore_conda_missmatch**: If true `--no-check-uptodate` is set when calling `conda smithy rerender`, this handles a situation when conda-smithy or conda-forge-pinning are not sync in the environment.
- **conda_rc**: Path to a file that will be used to configure conda.