### PR TITLE
Build tool update.2 --- use **kwargs

### DIFF
--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -166,7 +166,7 @@ if is_conda_forge_pkg:
         status = rerender_in_local_feedstock(**kwargs)
 
     if args.do_build:
-        status = build_in_local_feedstock(**kwargs
+        status = build_in_local_feedstock(**kwargs)
 
 else:
     print("Building non conda-forge package")

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -118,7 +118,7 @@ def check_if_conda_forge_pkg(pkg_name):
         print("{p} is not a conda-forge package".format(p=pkg_name))
         return False
 
-def clone_feedstock(package_name, workdir):
+def clone_feedstock(package_name, workdir, **kwargs):
     pkg_feedstock = "{p}-feedstock".format(p=package_name)
     conda_forge_pkg_feedstock = "conda-forge/{p}".format(p=pkg_feedstock)
 


### PR DESCRIPTION
@jasonb5  I created this branch off your build_tool_update to use **kwargs in some of the routines in build_tools/release_tools.py.

I used cdat_info (branch 'makefile_n_matrix') to test out the changes.
https://circleci.com/gh/CDAT/cdat_info/tree/makefile_n_matrix