### PR TITLE
update prepare_recipe_in_local_feedstock() to copy over recipe from repo to fake feedstock 

### DIFF
--- a/build_tools/conda_build.py
+++ b/build_tools/conda_build.py
@@ -148,7 +148,8 @@ else:
 print("repo_dir: {d}".format(d=repo_dir))
 files = ["recipe/conda_build_config.yaml",
          "recipe/build.sh",
-         ".ci_support/migrations/python38.yaml"]
+         ".ci_support/migrations/python38.yaml",
+         ".ci_support/migrations/hdf51106.yaml"]
 
 if is_conda_forge_pkg:
     if args.do_rerender:

--- a/build_tools/release_tools.py
+++ b/build_tools/release_tools.py
@@ -162,6 +162,17 @@ def prepare_recipe_in_local_feedstock_repo(package_name, organization, repo_name
     # merge this recipe to feedstock and delete the recipe from the repo.
     #
     repo_recipe = os.path.join(repo_dir, "recipe", "meta.yaml.in")
+
+    #
+    # if branch name starts with 'for_release', we are building a non conda-forge
+    # package for a release, and the branch should have the recipe ready for
+    # rerender, so just copy over to the fake feedstock.
+    #
+    for_release = branch.startswith("for_release")
+    if for_release:
+        shutil.copyfile(repo_recipe, recipe_file)
+        return SUCCESS
+
     if os.path.isfile(repo_recipe):
         print("\nNOTE: {r} exists, we will build using this recipe.\n".format(r=repo_recipe))
         recipe_file_source = repo_recipe


### PR DESCRIPTION
updated prepare_recipe_in_local_feedstock_repo() to check if branch starts with "for_release_".
if so, the branch has recipe/meta.yaml.in that has been updated with url and sha256 for the release, and the recipe
can be just copied over to the fake feedstock. (this is only for building non conda-forge package).
This for_release branch does not get merged to the master branch of the project though, just use it for building a release package.
We need to come up with a better way.

also add copying migrations/hdf51106.yaml file from repo dir to fake feedstock, this is needed for building non conda-forge package.